### PR TITLE
Allow reusing bind parameters for the postgres backend rather than duplicating for each instance.

### DIFF
--- a/AbstractSQLRules2SQL.js
+++ b/AbstractSQLRules2SQL.js
@@ -1159,7 +1159,19 @@
             });
         }
     })).AddBind = function(bind) {
+        if ("postgres" === this.engine) {
+            if ("Bind" === bind[0]) {
+                var existingBindIndex = _.findIndex(this.fieldOrderings, function(existingBind) {
+                    return _.isEqual(bind, existingBind);
+                });
+                if (-1 !== existingBindIndex) {
+                    existingBindIndex += 1;
+                    return "$" + existingBindIndex;
+                }
+            }
+            return "$" + this.fieldOrderings.push(bind);
+        }
         this.fieldOrderings.push(bind);
-        return "postgres" === this.engine ? "$" + this.fieldOrderings.length : "?";
+        return "?";
     };
 });

--- a/AbstractSQLRules2SQL.ometajs
+++ b/AbstractSQLRules2SQL.ometajs
@@ -757,10 +757,20 @@ export ometa AbstractSQLRules2SQL {
 }
 
 AbstractSQLRules2SQL.AddBind = function(bind) {
-	this.fieldOrderings.push(bind);
 	if (this.engine === 'postgres') {
-		return '$' + this.fieldOrderings.length;
+		if (bind[0] === 'Bind') {
+			var existingBindIndex = _.findIndex(this.fieldOrderings, function(existingBind) {
+				return _.isEqual(bind, existingBind);
+			});
+			if (existingBindIndex !== -1) {
+				// Reuse the existing bind if there is one, adding 1 because the postgres binds start from $1
+				existingBindIndex = existingBindIndex + 1;
+				return '$' + existingBindIndex;
+			}
+		}
+		return '$' + this.fieldOrderings.push(bind);
 	} else {
+		this.fieldOrderings.push(bind);
 		return '?';
 	}
 };

--- a/test/odata/filterby.coffee
+++ b/test/odata/filterby.coffee
@@ -357,6 +357,27 @@ do ->
 			operandTest(mathOp, 'gt', 10)
 
 run ->
+	odata = "name eq @name&@name='Pete'"
+	test "/pilot?$filter=#{odata}", 'GET', [['Bind', '@name']], (result, sqlEquals) ->
+		it 'should select from pilot where "' + odata + '"', ->
+			sqlEquals result.query, """
+				SELECT #{pilotFields}
+				FROM "pilot"
+				WHERE "pilot"."name" = ?
+			"""
+
+run ->
+	odata = "name eq @x or favourite_colour eq @x&@x='Amber'"
+	test "/pilot?$filter=#{odata}", 'GET', [['Bind', '@x']], (result, sqlEquals) ->
+		it 'should select from pilot where "' + odata + '"', ->
+			sqlEquals result.query, """
+				SELECT #{pilotFields}
+				FROM "pilot"
+				WHERE ("pilot"."name" = $1
+				OR "pilot"."favourite colour" = $1)
+			"""
+
+run ->
 	{ odata, bindings, sql } = createExpression('can_fly__plane/id', 'eq', 10)
 	test "/pilot?$filter=#{odata}", 'GET', bindings, (result, sqlEquals) ->
 		it 'should select from pilot where "' + odata + '"', ->


### PR DESCRIPTION
This allows us to avoid redundant validation of bind vars in https://github.com/resin-io/pinejs/blob/86c0e155622f7a2056c304dd21c8dcd0744e5d00/src/sbvr-api/sbvr-utils.coffee#L161-L203 and also avoid sending the same variable to postgres multiple times.  This is particularly big when combined with `@__ACTOR_ID` of https://github.com/resin-io/pinejs/pull/179 which will mean the actor id will benefit from this, as the actor id can appear a lot of times in a query due to permissions

Change-type: minor